### PR TITLE
Era/tech based strength bonus for land units should only be applied while on land

### DIFF
--- a/jsons/Units.json
+++ b/jsons/Units.json
@@ -272,7 +272,7 @@
 			"'Infantry'",
 			"'Dense Formation'",
 			"'Edged Weapons'",
-			"[+50]% Strength <starting from the [Classical era]>",
+			"[+50]% Strength <starting from the [Classical era]> <in [Land] tiles>",
 			"[This Unit] takes [25] damage <upon ending a turn in a [Ocean] tile> <before discovering [Cartography]>",
 			"Never appears as a Barbarian unit"
 		],
@@ -323,8 +323,8 @@
 			"'Infantry'",
 			"'Dense Formation'",
 			"'Edged Weapons'",
-			"[+25]% Strength <after discovering [Armorments]>",
-			"[+50]% Strength <after discovering [Tactics]>",
+			"[+25]% Strength <after discovering [Armorments]> <in [Land] tiles>",
+			"[+50]% Strength <after discovering [Tactics]> <in [Land] tiles>",
 			"Founds a new puppet city <by consuming this unit>",
 			"[This Unit] takes [25] damage <upon ending a turn in a [Ocean] tile> <before discovering [Cartography]>",
 			"Never appears as a Barbarian unit"
@@ -520,7 +520,7 @@
 			"'Edged Weapons'",
 			"[-20]% Strength <when defending>",
 			"[-33]% Strength <vs cities> <when attacking>",
-			"Can transform to [Cataphract] <after discovering [Armorments]><removing the [The Noble Army] promotion/status>",
+			"Can transform to [Cataphract] <after discovering [Armorments]> <removing the [The Noble Army] promotion/status>",
 			"[This Unit] takes [25] damage <upon ending a turn in a [Ocean] tile> <before discovering [Cartography]>",
 			"Never appears as a Barbarian unit"
 		],
@@ -548,7 +548,7 @@
 			"'Edged Weapons'",
 			"[-20]% Strength <when defending>",
 			"[-20]% Strength <vs cities> <when attacking>",
-			"Can transform to [Cataphract] <after discovering [Armorments]><removing the [The Noble Army] promotion/status>",
+			"Can transform to [Cataphract] <after discovering [Armorments]> <removing the [The Noble Army] promotion/status>",
 			"[This Unit] takes [25] damage <upon ending a turn in a [Ocean] tile> <before discovering [Cartography]>",
 			"Never appears as a Barbarian unit"
 		],
@@ -743,8 +743,8 @@
 			"'Dense Formation'",
 			"'Blunt Weapons'",
 			"No defensive terrain bonus",
-			"[+50]% Strength <after discovering [Armorments]>",
-			"[+25]% Strength <after discovering [Tactics]>",
+			"[+50]% Strength <after discovering [Armorments]> <in [Land] tiles>",
+			"[+25]% Strength <after discovering [Tactics]> <in [Land] tiles>",
 			"[-25]% Strength <vs cities> <when attacking>",
 			"[-33]% Strength <vs ['Siege Weapons'] units>",
 			"[-33]% Strength <vs ['Firearms'] units>",
@@ -776,9 +776,9 @@
 			"'Edged Weapons'",
 			"No defensive terrain bonus",
 			"[+1] Sight",
-			"[+33]% Strength <after discovering [Stirrup]>",
-			"[+25]% Strength <after discovering [Armorments]>",
-			"[+25]% Strength <after discovering [Tactics]>",
+			"[+33]% Strength <after discovering [Stirrup]> <in [Land] tiles>",
+			"[+25]% Strength <after discovering [Armorments]> <in [Land] tiles>",
+			"[+25]% Strength <after discovering [Tactics]> <in [Land] tiles>",
 			"[This Unit] takes [25] damage <upon ending a turn in a [Ocean] tile> <before discovering [Cartography]>",
 			"Never appears as a Barbarian unit"
 		],
@@ -951,8 +951,8 @@
 			"'Infantry'",
 			"'Dense Formation'",
 			"'Edged Weapons'",
-			"[+25]% Strength <after discovering [Armorments]>",
-			"[+50]% Strength <after discovering [Tactics]>",
+			"[+25]% Strength <after discovering [Armorments]> <in [Land] tiles>",
+			"[+50]% Strength <after discovering [Tactics]> <in [Land] tiles>",
 			"[This Unit] takes [25] damage <upon ending a turn in a [Ocean] tile> <before discovering [Cartography]>",
 			"Never appears as a Barbarian unit"
 		],
@@ -971,15 +971,15 @@
 		"movement": 2,
 		"strength": 24,
 		"uniques": [
-			"Can upgrade to [Revolutionaries] <after discovering [Flintlock]><after adopting [Long Live the Revolution!]>",
+			"Can upgrade to [Revolutionaries] <after discovering [Flintlock]> <after adopting [Long Live the Revolution!]>",
 			"Consumes [1] [Metal]",
 			"'Standing Army'",
 			"'Infantry'",
 			"'Dense Formation'",
 			"'Edged Weapons'",
 			"[+25]% Strength <when fighting in [Rough terrain] tiles>",
-			"[+25]% Strength <after discovering [Tactics]>",
-			"[+10]% Strength <after discovering [Steels]>",
+			"[+25]% Strength <after discovering [Tactics]> <in [Land] tiles>",
+			"[+10]% Strength <after discovering [Steels]> <in [Land] tiles>",
 			"[This Unit] takes [25] damage <upon ending a turn in a [Ocean] tile> <before discovering [Cartography]>",
 			"Never appears as a Barbarian unit"
 		],
@@ -1000,16 +1000,16 @@
 		"strength": 26,
 		"uniques": [
 			"Can upgrade to [Knight] <after discovering [Tactics]><after adopting [Feudalism]>",
-			"Can transform to [Revolutionaries] <after discovering [Flintlock]><after adopting [Long Live the Revolution!]><removing the [The Noble Army] promotion/status>",
-			"Can transform to [Grenadier] <after discovering [Flintlock]><removing the [The Noble Army] promotion/status>",
+			"Can transform to [Revolutionaries] <after discovering [Flintlock]> <after adopting [Long Live the Revolution!]> <removing the [The Noble Army] promotion/status>",
+			"Can transform to [Grenadier] <after discovering [Flintlock]> <removing the [The Noble Army] promotion/status>",
 			"Consumes [1] [Metal]",
 			"'Noble Army'",
 			"'Infantry'",
 			"'Dense Formation'",
 			"'Edged Weapons'",
 			"[+25]% Strength <when fighting in [Rough terrain] tiles>",
-			"[+25]% Strength <after discovering [Tactics]>",
-			"[+10]% Strength <after discovering [Steels]>",
+			"[+25]% Strength <after discovering [Tactics]> <in [Land] tiles>",
+			"[+10]% Strength <after discovering [Steels]> <in [Land] tiles>",
 			"[This Unit] takes [25] damage <upon ending a turn in a [Ocean] tile> <before discovering [Cartography]>",
 			"Never appears as a Barbarian unit"
 		],
@@ -1119,8 +1119,8 @@
 			"'Infantry'",
 			"'Dense Formation'",
 			"'Edged Weapons'",
-			"[+33]% Strength <after discovering [Armorments]>",
-			"[+50]% Strength <after discovering [Tactics]>",
+			"[+33]% Strength <after discovering [Armorments]> <in [Land] tiles>",
+			"[+50]% Strength <after discovering [Tactics]> <in [Land] tiles>",
 			"[+13]% Strength <in [Friendly Land] tiles> <when defending>",
 			"[-33]% Strength <when attacking>",
 			"[This Unit] takes [25] damage <upon ending a turn in a [Ocean] tile> <before discovering [Cartography]>",
@@ -1336,8 +1336,8 @@
 			"'Dense Formation'",
 			"'Edged Weapons'",
 			"[+25]% Strength <when fighting in [Rough terrain] tiles>",
-			"[+25]% Strength <after discovering [Tactics]>",
-			"[+10]% Strength <after discovering [Steels]>",
+			"[+25]% Strength <after discovering [Tactics]> <in [Land] tiles>",
+			"[+10]% Strength <after discovering [Steels]> <in [Land] tiles>",
 			"Can move immediately once bought",
 			"[This Unit] takes [25] damage <upon ending a turn in a [Ocean] tile> <before discovering [Cartography]>",
 			"Never appears as a Barbarian unit"
@@ -1467,7 +1467,7 @@
 			"'Edged Weapons'",
 			"No defensive terrain bonus",
 			"[+1] Sight",
-			"[+25]% Strength <after discovering [Tactics]>",
+			"[+25]% Strength <after discovering [Tactics]> <in [Land] tiles>",
 			"[This Unit] takes [25] damage <upon ending a turn in a [Ocean] tile> <before discovering [Cartography]>",
 			"Never appears as a Barbarian unit"
 		],
@@ -1498,7 +1498,7 @@
 			"'Edged Weapons'",
 			"No defensive terrain bonus",
 			"[+1] Sight",
-			"[+25]% Strength <after discovering [Tactics]>",
+			"[+25]% Strength <after discovering [Tactics]> <in [Land] tiles>",
 			"[This Unit] takes [25] damage <upon ending a turn in a [Ocean] tile> <before discovering [Cartography]>",
 			"Never appears as a Barbarian unit"
 		],
@@ -1527,7 +1527,7 @@
 			"'Dense Formation'",
 			"'Edged Weapons'",
 			"No defensive terrain bonus",
-			"[+25]% Strength <after discovering [Tactics]>",
+			"[+25]% Strength <after discovering [Tactics]> <in [Land] tiles>",
 			"Can move immediately once bought",
 			"[This Unit] takes [25] damage <upon ending a turn in a [Ocean] tile> <before discovering [Cartography]>",
 			"Never appears as a Barbarian unit"
@@ -1642,7 +1642,7 @@
 			"'Dense Formation'",
 			"'Edged Weapons'",
 			"[+25]% Strength <when fighting in [Rough terrain] tiles>",
-			"[+15]% Strength <after discovering [Steels]>",
+			"[+15]% Strength <after discovering [Steels]> <in [Land] tiles>",
 			"[This Unit] takes [25] damage <upon ending a turn in a [Ocean] tile> <before discovering [Cartography]>",
 			"Never appears as a Barbarian unit"
 		],
@@ -2281,7 +2281,7 @@
 			"'Dense Formation'",
 			"Can move immediately once bought",
 			"Never appears as a Barbarian unit",
-			"[+33]% Strength <after discovering [Rifling]>"
+			"[+33]% Strength <after discovering [Rifling]> <in [Land] tiles>"
 		],
 		"promotions": [
 			"Mercenary Habit"
@@ -2330,7 +2330,7 @@
 			"'Dense Formation'",
 			"[+15]% Strength <when fighting in [Rough terrain] tiles>",
 			"Never appears as a Barbarian unit",
-			"[+33]% Strength <after discovering [Rifling]>"
+			"[+33]% Strength <after discovering [Rifling]> <in [Land] tiles>"
 		],
 		"promotions": [
 			"The Standing Army"
@@ -2357,7 +2357,7 @@
 			"'Dense Formation'",
 			"[+7]% Strength bonus for [Military] units within [2] tiles",
 			"Never appears as a Barbarian unit",
-			"[+33]% Strength <after discovering [Rifling]>"
+			"[+33]% Strength <after discovering [Rifling]> <in [Land] tiles>"
 		],
 		"promotions": [
 			"The Standing Army"
@@ -3133,8 +3133,8 @@
 			"'Dense Formation'",
 			"'Firearms'",
 			"Can move after attacking",
-			"[+25]% Strength <after discovering [Mobile Tactics]>",
-			"[+25]% Strength <after discovering [Lasers]>",
+			"[+25]% Strength <after discovering [Mobile Tactics]> <in [Land] tiles>",
+			"[+25]% Strength <after discovering [Lasers]> <in [Land] tiles>",
 			"No defensive terrain bonus",
 			"Never appears as a Barbarian unit"
 		],
@@ -4189,10 +4189,10 @@
 			"'Dense Formation'",
 			"'Edged Weapons'",
 			"Cannot embark",
-			"[+50]% Strength <starting from the [Classical era]>",
-			"[+100]% Strength <starting from the [Medieval era]>",
-			"[+100]% Strength <starting from the [Renaissance era]>",
-			"[+100]% Strength <starting from the [Imperial era]>",
+			"[+50]% Strength <starting from the [Classical era]> <in [Land] tiles>",
+			"[+100]% Strength <starting from the [Medieval era]> <in [Land] tiles>",
+			"[+100]% Strength <starting from the [Renaissance era]> <in [Land] tiles>",
+			"[+100]% Strength <starting from the [Imperial era]> <in [Land] tiles>",
 			"Cannot enter ocean tiles"
 		],
 		"promotions": [
@@ -4213,10 +4213,10 @@
 			"'Skirmishers'",
 			"'Edged Weapons'",
 			"Cannot embark",
-			"[+50]% Strength <starting from the [Classical era]>",
-			"[+200]% Strength <starting from the [Medieval era]>",
-			"[+200]% Strength <starting from the [Renaissance era]>",
-			"[+300]% Strength <starting from the [Imperial era]>",
+			"[+50]% Strength <starting from the [Classical era]> <in [Land] tiles>",
+			"[+200]% Strength <starting from the [Medieval era]> <in [Land] tiles>",
+			"[+200]% Strength <starting from the [Renaissance era]> <in [Land] tiles>",
+			"[+300]% Strength <starting from the [Imperial era]> <in [Land] tiles>",
 			"Can move after attacking"
 		],
 		"promotions": [
@@ -4239,9 +4239,9 @@
 			"'Dense Formation'",
 			"'Edged Weapons'",
 			"Cannot embark",
-			"[+50]% Strength <starting from the [Medieval era]>",
-			"[+100]% Strength <starting from the [Renaissance era]>",
-			"[+100]% Strength <starting from the [Imperial era]>"
+			"[+50]% Strength <starting from the [Medieval era]> <in [Land] tiles>",
+			"[+100]% Strength <starting from the [Renaissance era]> <in [Land] tiles>",
+			"[+100]% Strength <starting from the [Imperial era]> <in [Land] tiles>"
 		],
 		"promotions": [
 			"Barbaric"
@@ -4264,8 +4264,8 @@
 			"'Skirmishers'",
 			"'Edged Weapons'",
 			"Cannot embark",
-			"[+50]% Strength <starting from the [Medieval era]>",
-			"[+50]% Strength <starting from the [Renaissance era]>"
+			"[+50]% Strength <starting from the [Medieval era]> <in [Land] tiles>",
+			"[+50]% Strength <starting from the [Renaissance era]> <in [Land] tiles>"
 		],
 		"promotions": [
 			"Barbaric",
@@ -4288,9 +4288,9 @@
 			"'Dense Formation'",
 			"'Edged Weapons'",
 			"Cannot embark",
-			"[+50]% Strength <starting from the [Medieval era]>",
-			"[+100]% Strength <starting from the [Renaissance era]>",
-			"[+100]% Strength <starting from the [Imperial era]>"
+			"[+50]% Strength <starting from the [Medieval era]> <in [Land] tiles>",
+			"[+100]% Strength <starting from the [Renaissance era]> <in [Land] tiles>",
+			"[+100]% Strength <starting from the [Imperial era]> <in [Land] tiles>"
 		],
 		"promotions": [
 			"Barbaric"
@@ -4312,8 +4312,8 @@
 			"'Skirmishers'",
 			"'Firearms'",
 			"Cannot embark",
-			"[+25]% Strength <starting from the [Industrial era]>",
-			"[+25]% Strength <starting from the [Modern era]>"
+			"[+25]% Strength <starting from the [Industrial era]> <in [Land] tiles>",
+			"[+25]% Strength <starting from the [Modern era]> <in [Land] tiles>"
 		],
 		"promotions": [
 			"Barbaric"
@@ -4333,7 +4333,7 @@
 			"'Skirmishers'",
 			"'Firearms'",
 			"Cannot embark",
-			"[+50]% Strength <starting from the [Modern era]>"
+			"[+50]% Strength <starting from the [Modern era]> <in [Land] tiles>"
 		],
 		"promotions": [
 			"Asymmetric Warfare",
@@ -4355,7 +4355,7 @@
 			"'Firearms'",
 			"'Levy Army'",
 			"Cannot embark",
-			"[+50]% Strength <starting from the [Atomic era]>"
+			"[+50]% Strength <starting from the [Atomic era]> <in [Land] tiles>"
 		],
 		"promotions": [
 			"Asymmetric Warfare",
@@ -4377,8 +4377,8 @@
 			"'Dense Formation'",
 			"'Firearms'",
 			"Cannot embark",
-			"[+25]% Strength <starting from the [Industrial era]>",
-			"[+25]% Strength <starting from the [Modern era]>"
+			"[+25]% Strength <starting from the [Industrial era]> <in [Land] tiles>",
+			"[+25]% Strength <starting from the [Modern era]> <in [Land] tiles>"
 		],
 		"promotions": [
 			"Barbaric"


### PR DESCRIPTION
Era/tech based strength bonus for land units should only be applied while on land, so they **don't** get bonus while _embarked on water_