### PR TITLE
Some changes I'd suggest

### DIFF
--- a/jsons/TileImprovements.json
+++ b/jsons/TileImprovements.json
@@ -342,6 +342,9 @@
 		"techRequired": "Electricity",
 		"uniques": [
 			"'Infrastructure Improvement'",
+			"Provides [1] [Power]",
+			"Provides [1] [Power] <in [River] tiles> <in tiles not adjacent to [Water] tiles>",
+			"Provides [1] [Power] <in tiles adjacent to [Water] tiles>",
 			"Pillaging this improvement yields approximately [+20 Gold]"
 		],
 		"shortcutKey": "P"

--- a/jsons/TileResources.json
+++ b/jsons/TileResources.json
@@ -56,7 +56,7 @@
 	{
 		"name": "Consumption Demand",
 		"resourceType": "Strategic",
-		"uniques": [],
+		"uniques": ["Cannot be traded"],
 		"revealedBy": "Economics"
 	},
 	{


### PR DESCRIPTION
Up to you to decide whether they would be included or not.

Two suggested changes, mainly:
- Made Consumption Demand non-tradeable so the city states won't throw their own goods demands on you that would screw up the entire supply-demand balance f*'d up beyond any repair
- Made power plant tile improvement as supplementary source of power. Provides power to the city that the tile PP belongs to. Additional power if it has adjacent water access (river or water tile).