### PR TITLE
Spelling

### DIFF
--- a/jsons/Nations.json
+++ b/jsons/Nations.json
@@ -473,7 +473,7 @@
 	},
 	{
 		"name": "Europa",
-		"leaderName": "Celts, Germanen, Slavs and many others",
+		"leaderName": "Celts, Germans, Slavs and many others",
 		"adjective": [
 			"European"
 		],

--- a/jsons/translations/English.properties
+++ b/jsons/translations/English.properties
@@ -4625,7 +4625,7 @@ An unique government form that provides elite military units, mutually exclusive
 An unique government form that provides a way to profitise expansion, mutually exclusive from[Chu Dynasty] = 
 
  # Requires translation!
-Celts, Germanen, Slavs and many others = 
+Celts, Germans, Slavs and many others = 
  # Requires translation!
 You can destroy our body, kill all our kind, but our legacy remains. = 
  # Requires translation!

--- a/jsons/translations/French.properties
+++ b/jsons/translations/French.properties
@@ -3877,7 +3877,7 @@ An unique government form that provides elite military units, mutually exclusive
 An unique government form that provides a way to profitise expansion, mutually exclusive from[Chu Dynasty] = 
 
  # Requires translation!
-Celts, Germanen, Slavs and many others = 
+Celts, Germans, Slavs and many others = 
  # Requires translation!
 You can destroy our body, kill all our kind, but our legacy remains. = 
  # Requires translation!

--- a/jsons/translations/German.properties
+++ b/jsons/translations/German.properties
@@ -2767,7 +2767,7 @@ An unique government form that provides elite military units and unique bonuses,
 An unique government form that provides elite military units, mutually exclusive from[Han Dynasty] = Eine einzigartige Regierungsform, die Elite-Militäreinheiten bietet, gegenseitig ausschließend mit der [Han Dynasty]
 An unique government form that provides a way to profitise expansion, mutually exclusive from[Chu Dynasty] = Eine einzigartige Regierungsform, die eine Möglichkeit bietet, Expansion zu profitieren, gegenseitig ausschließend mit der [Chu Dynasty]
 
-Celts, Germanen, Slavs and many others = Kelten, Germanen, Slawen und viele andere
+Celts, Germans, Slavs and many others = Kelten, Germanen, Slawen und viele andere
 You can destroy our body, kill all our kind, but our legacy remains. = Ihr könnt unseren Körper zerstören, unsere ganze Art töten, aber unser Vermächtnis bleibt.
 From Ireland to the Urals = Von Irland bis zum Ural
 Europa is a huge-sized bundle of nations, mainly the Known empires located in the parts of europe north of the Alps, consist of the main land part of europe, where enlightenment, industrial revolution and world wars came from. = Europa ist ein riesiges Bündel von Nationen, hauptsächlich die bekannten Imperien in den Teilen Europas nördlich der Alpen, bestehend aus dem Festlandteil Europas, wo Aufklärung, industrielle Revolution und Weltkriege herkamen.

--- a/jsons/translations/Russian.properties
+++ b/jsons/translations/Russian.properties
@@ -2640,7 +2640,7 @@ An unique government form that provides elite military units, mutually exclusive
  
 An unique government form that provides a way to profitise expansion, mutually exclusive from[Chu Dynasty] = Уникальная форма правления, обеспечивающая возможность получения прибыли от экспансии, взаимоисключающая с [Chu Dynasty]
 
-Celts, Germanen, Slavs and many others = Кельты, Германцы, Славяне и многие другие
+Celts, Germans, Slavs and many others = Кельты, Германцы, Славяне и многие другие
 You can destroy our body, kill all our kind, but our legacy remains. = Вы можете уничтожить наши тела, убить весь наш род, но наше наследие останется.
 From Ireland to the Urals = От Ирландии до Урала
  

--- a/jsons/translations/Simplified_Chinese.properties
+++ b/jsons/translations/Simplified_Chinese.properties
@@ -2411,7 +2411,7 @@ An unique government form that provides elite military units and unique bonuses,
 An unique government form that provides elite military units, mutually exclusive from[Han Dynasty] = 独特形态，提供精英单位，和[Han Dynasty]互斥
 An unique government form that provides a way to profitise expansion, mutually exclusive from[Chu Dynasty] = 独特形态，提高扩张收益，和[Chu Dynasty]互斥
 
-Celts, Germanen, Slavs and many others = 凯尔特人，日耳曼人，斯拉夫人以及其他民族
+Celts, Germans, Slavs and many others = 凯尔特人，日耳曼人，斯拉夫人以及其他民族
 You can destroy our body, kill all our kind, but our legacy remains. = 你可毁灭我们的躯体，屠杀我们的同胞，但我们的遗产永存。
 From Ireland to the Urals = 从爱尔兰到乌拉尔
 Europa is a huge-sized bundle of nations, mainly the Known empires located in the parts of europe north of the Alps, consist of the main land part of europe, where enlightenment, industrial revolution and world wars came from. = 欧洲文明包含巨量的民族，它们建立了阿尔卑斯山以北的诸多帝国，是欧洲的大陆部分，思想启蒙，工业革命以及世界大战都由此发源。

--- a/jsons/translations/Traditional_Chinese.properties
+++ b/jsons/translations/Traditional_Chinese.properties
@@ -2411,7 +2411,7 @@ An unique government form that provides elite military units and unique bonuses,
 An unique government form that provides elite military units, mutually exclusive from[Han Dynasty] = 獨特形態，提供精英單位，和[Han Dynasty]互斥
 An unique government form that provides a way to profitise expansion, mutually exclusive from[Chu Dynasty] = 獨特形態，提高擴張收益，和[Chu Dynasty]互斥
 
-Celts, Germanen, Slavs and many others = 凱爾特人，日耳曼人，斯拉夫人以及其他民族
+Celts, Germans, Slavs and many others = 凱爾特人，日耳曼人，斯拉夫人以及其他民族
 You can destroy our body, kill all our kind, but our legacy remains. = 你可毀滅我們的軀體，屠殺我們的同胞，但我們的遺產永存。
 From Ireland to the Urals = 從愛爾蘭到烏拉爾
 Europa is a huge-sized bundle of nations, mainly the Known empires located in the parts of europe north of the Alps, consist of the main land part of europe, where enlightenment, industrial revolution and world wars came from. = 歐洲文明包含巨量的民族，它們建立了阿爾卑斯山以北的諸多帝國，是歐洲的大陸部分，思想啟蒙，工業革命以及世界大戰都由此發源。


### PR DESCRIPTION
Germanen should simply be Germans.